### PR TITLE
Add use case: remove PII from Office files (Python)

### DIFF
--- a/python-net/use-cases/_index.md
+++ b/python-net/use-cases/_index.md
@@ -1,4 +1,4 @@
----
+﻿---
 id: use-cases
 url: metadata/python-net/use-cases
 title: Use Cases
@@ -15,3 +15,4 @@ This section collects practical scenarios for **GroupDocs.Metadata for Python vi
 Use these guides when you are building audit tooling, records workflows, or document forensics scripts in Python and want to see the property search engine applied to a concrete business problem.
 
 ### Pages in this section
+- [5 PII Removal Methods for Office Files - Complete Comparison Guide](/metadata/python-net/use-cases/remove-pii-from-office-files/) – Compare targeted removal passes, the full sanitize, and a leak-check verification for Word, Excel, and PowerPoint files.

--- a/python-net/use-cases/remove-pii-from-office-files.md
+++ b/python-net/use-cases/remove-pii-from-office-files.md
@@ -1,0 +1,244 @@
+---
+id: remove-pii-from-office-files
+url: /metadata/python-net/use-cases/remove-pii-from-office-files/
+title: 5 PII Removal Methods for Office Files - Complete Comparison Guide
+weight: 1
+description: "Compare five ways to remove personal data from Word, Excel, and PowerPoint metadata using GroupDocs.Metadata for Python via .NET, plus a verification scan that proves the cleanup."
+keywords: remove pii, document sanitization, office metadata, python metadata removal, gdpr documents, clean docx properties, metadata leak check, groupdocs metadata
+productName: GroupDocs.Metadata for Python via .NET
+structuredData:
+    showOrganization: True
+toc: true
+draft: true
+---
+
+{{< alert style="info" >}}
+💡 Full working example available on GitHub:
+[sanitize-office-document-pii-python](https://github.com/groupdocs-metadata/sanitize-office-document-pii-python)
+{{< /alert >}}
+
+## Introduction
+
+PII removal is a GroupDocs.Metadata capability for Python via .NET that strips identity-bearing properties from Word, Excel, and PowerPoint files before they leave your organization. Five methods exist instead of one because "remove personal data" means different things at different moments. During collaboration you want surgical passes that clear author names but keep Title and Subject usable. At the trust boundary you want everything gone. After either choice you want proof. Office files scatter identity data across built-in properties, custom parts, and server-injected fields, so each removal target calls for its own predicate.
+
+This guide compares four targeted removal passes and one full sanitize, all drawn from a runnable repository, and closes with the verification function that separates a clean file from a lucky one.
+
+## What This Guide Covers
+
+You will see the exact predicate each pass uses, when a substring rule beats a tag rule, and why the one-call `sanitize()` is both the strongest and the bluntest tool in the set. Every code block comes from the linked repository, which seeds a sample DOCX, runs all six functions, and asserts each result. The layout is small: `main.py` drives six functions from `methods/`, reads `resources/pii-sample.docx`, and writes five cleaned copies into `output/`.
+
+**Prerequisites:**
+- Python 3 with pip available
+- `pip install groupdocs-metadata-net==26.5` (the version the repository pins)
+
+## Quick Decision Matrix
+
+| Scenario | Recommended Method | Why |
+|----------|------------------|-----|
+| Share a draft externally, keep it editable | Identity pass | Clears names, keeps descriptive fields |
+| Publish minutes with review threads removed | Comment pass | Targets reviewer fields only |
+| Release a file whose edit history is confidential | Revision pass | Clears counters and time trails |
+| Ship files exported from SharePoint | Server pass | Drops workflow and approver fields |
+| Final export outside the organization | Full sanitize | Removes every detected package |
+
+## Detailed Method Analysis
+
+### Method 1: Targeted identity removal
+
+**Overview:** clears Author, LastSavedBy, Manager, and Company, the four fields that most directly name people and organizations.
+
+#### How It Works
+
+The predicate matches properties by semantic tag rather than by name. `Tags.person.creator`, `Tags.person.editor`, `Tags.person.manager`, and `Tags.corporate.company` classify identity fields across every Office format, so the same lambda serves DOCX, XLSX, and PPTX without format-specific code. Use it on drafts that must stay useful after cleaning and as the opening step of a GDPR or ISO 27001 pre-publication workflow. Do not rely on it alone for final exports; leftover custom fields may still carry names.
+
+#### Implementation
+
+```python
+with Metadata(input_path) as metadata:
+    affected = metadata.remove_properties(lambda p:
+        Tags.person.creator in list(p.tags)
+        or Tags.person.editor in list(p.tags)
+        or Tags.person.manager in list(p.tags)
+        or Tags.corporate.company in list(p.tags))
+    metadata.save(output_path)
+    return affected
+```
+
+Tag matching means no property names are hard-coded, and formats exposing the same tags are covered automatically. The trade-off is scope. Custom properties that carry names without carrying identity tags pass through untouched; the later passes and the leak check exist for exactly that gap.
+
+### Method 2: Comment and reviewer cleanup
+
+**Overview:** removes Comment, Reviewer, and Reviewed properties, the fields that preserve internal discussion history and reviewer identities.
+
+#### How It Works
+
+This pass switches from tags to name substrings, because comment-related fields are often custom properties the tag system does not classify. Three broad rules over `p.name` catch `Comments`, `CommentCount`, and vendor-specific variants in one predicate. Reach for it when publishing documents that went through internal review. It does not touch the comment balloons in the Word body; those are content, not metadata.
+
+#### Implementation
+
+```python
+with Metadata(input_path) as metadata:
+    affected = metadata.remove_properties(lambda p:
+        p.name is not None and (
+            "Comment" in p.name
+            or "Reviewer" in p.name
+            or "Reviewed" in p.name))
+    metadata.save(output_path)
+    return affected
+```
+
+Substring rules trade precision for reach. They remove any custom property whose name mentions comments, which is normally what a sanitization pass wants. Audit the affected count if your templates use those words for something harmless.
+
+### Method 3: Revision-trail removal
+
+**Overview:** clears Revision, TrackedChange, LastPrinted, TotalEditingTime, and EditTime properties, the group that reconstructs who edited a file and for how long.
+
+#### How It Works
+
+Five substring rules cover the editing-timeline family. The pass exists separately from the comment pass because revision data answers a different question: not "what was said" but "how long was this worked on and when did it last print", which is confidential in legal and procurement settings. It belongs in compliance-driven publishing and releases to counterparties.
+
+#### Implementation
+
+```python
+with Metadata(input_path) as metadata:
+    affected = metadata.remove_properties(lambda p:
+        p.name is not None and (
+            "Revision" in p.name
+            or "TrackedChange" in p.name
+            or "LastPrinted" in p.name
+            or "TotalEditingTime" in p.name
+            or "EditTime" in p.name))
+    metadata.save(output_path)
+    return affected
+```
+
+### Method 4: Server-property removal
+
+**Overview:** drops SharePoint and document-server fields whose names reference Server, Workflow, Approver, ContentType, or Template.
+
+#### How It Works
+
+Documents saved from SharePoint carry workflow paths, approver IDs, and content-type URIs that map your internal structure. These fields rarely surface in property inspectors, which makes them the least-audited group in the file. Run it on anything exported from SharePoint before external release. One caution: a file that must re-enter the workflow loses its approval state.
+
+#### Implementation
+
+```python
+with Metadata(input_path) as metadata:
+    affected = metadata.remove_properties(lambda p:
+        p.name is not None and (
+            "Server" in p.name
+            or "Workflow" in p.name
+            or "Approver" in p.name
+            or "ContentType" in p.name
+            or "Template" in p.name))
+    metadata.save(output_path)
+    return affected
+```
+
+### Method 5: Full sanitize
+
+**Overview:** `metadata.sanitize()` removes every detected metadata package in one call: identity fields, comments, revision history, tracked-change authors, and custom OOXML parts.
+
+#### How It Works
+
+Instead of asking which properties match a rule, `sanitize()` asks which packages exist and clears them all. It cannot miss a property a hand-written predicate forgot, so the repository runs it as the final gate. The [Clean metadata](https://docs.groupdocs.com/metadata/python-net/clean-metadata/) documentation describes the underlying behavior. Reserve it for the last step before a file crosses the organizational boundary; on working copies it erases Title, Subject, and category fields your DMS may index.
+
+#### Implementation
+
+```python
+with Metadata(input_path) as metadata:
+    affected = metadata.sanitize()
+    metadata.save(output_path)
+    return affected
+```
+
+### Can sanitize() replace the four targeted passes?
+
+Mostly, and that is the point of running it last. sanitize() removes every detected package, so it covers the identity, comment, revision, and server groups in one call. What it cannot do is preserve harmless fields like Title, and it never touches comments stored in the document body. Keep the targeted passes for working copies and reserve sanitize() for the final export.
+
+## Verifying the Result
+
+Removal without a read-back is a guess. The repository therefore ends with a scan that re-opens the cleaned file and hunts for survivors, combining the tag rules and name rules from all four targeted passes:
+
+```python
+report = LeakReport()
+with Metadata(path) as metadata:
+    def is_pii(p):
+        if p.name is None:
+            return False
+        tag_hit = (
+            Tags.person.creator in list(p.tags)
+            or Tags.person.editor in list(p.tags)
+            or Tags.person.manager in list(p.tags)
+            or Tags.corporate.company in list(p.tags)
+        )
+        name_hit = any(n in p.name for n in (
+            "Comment", "Reviewer", "Revision", "TrackedChange",
+            "Classification", "Department", "Server", "Workflow"))
+        return tag_hit or name_hit
+```
+
+Survivors with non-empty values are then sorted into two buckets, and the split is the honest part of the design:
+
+```python
+    for p in metadata.find_properties(is_pii):
+        value = (str(p.interpreted_value) if p.interpreted_value is not None
+                 else (str(p.value) if p.value is not None else ""))
+        if not value or value == "0" or value == "0.0":
+            continue
+        entry = f"{p.name}={value}"
+        name = p.name or ""
+        if (name.startswith("Comment") or name.startswith("Revision")
+            or name.startswith("Inspection")):
+            report.content_level_leaks.append(entry)
+        else:
+            report.metadata_leaks.append(entry)
+return report
+```
+
+`metadata_leaks` must come back empty for the file to count as sanitized. `content_level_leaks` lists Word comments and tracked changes that live inside `word/document.xml`; a metadata API cannot reach them, and removing them takes a content-editing library such as Aspose.Words. Reporting that boundary beats pretending it does not exist. I keep this scan wired into CI so a template change that reintroduces a Company field fails the build instead of shipping.
+
+## Real-World Use Cases
+
+A law firm publishing a settled agreement ran the comment pass and then the full sanitize on the export copy; the leak check reported zero metadata leaks and flagged two body-level comments for manual removal. An HR team whose report templates kept re-leaking Company and Manager fields moved the identity pass into the template build script and made the leak check the acceptance test, so every generated template now ships verified clean.
+
+## Common Pitfalls and How to Avoid Them
+
+1. **Trusting the removal count**
+   - **Problem:** `remove_properties` returns how many properties matched, not whether the file is clean.
+   - **Solution:** always re-open the output and scan it, the way `run_leak_check` does.
+
+2. **Expecting metadata passes to clear body content**
+   - **Problem:** Word comment balloons and tracked-change markup survive every pass here.
+   - **Solution:** treat `content_level_leaks` as a to-do list for a content-editing tool, not as noise.
+
+3. **Running sanitize() on working copies**
+   - **Problem:** descriptive fields your DMS indexes (Title, Subject) vanish along with the PII.
+   - **Solution:** use targeted passes mid-workflow and reserve `sanitize()` for the export copy, writing to `output_path` so the original survives.
+
+## FAQ
+
+**Q: Can I combine multiple methods in one predicate?**
+A: Yes. The verification scan already does this: its `is_pii` predicate merges the tag rules and all the name rules into a single lambda. Keep separate passes when you need separate affected-counts for audit logs; merge them to save file opens in batch jobs.
+
+**Q: Do these passes work on XLSX and PPTX?**
+A: The tag-based identity pass carries over unchanged because tags classify properties across formats. The substring passes also apply, though server field names vary between SharePoint versions, so test against your own files. The [remove metadata properties](https://docs.groupdocs.com/metadata/python-net/remove-metadata-properties/) docs page shows the same predicate pattern on other formats.
+
+**Q: How do I choose between tag predicates and name predicates?**
+A: Use tags when the concept is classified (people, companies, timestamps) because they survive format differences. Use name substrings for field families the tag system does not cover, like comment counts and workflow fields. The repository needs both, and the decision matrix above maps each group to its pass.
+
+## Conclusion
+
+Four targeted passes, one full sanitize, one verification scan. That set covers the practical range: surgical cleanup while a file is being worked on, total cleanup when it leaves, and proof either way. Start with the identity pass if your files are hand-authored, add the server pass the moment SharePoint is involved, and never skip the read-back.
+
+**Next Steps:**
+- Explore the [complete source code](https://github.com/groupdocs-metadata/sanitize-office-document-pii-python) on GitHub
+- Review the [API documentation](https://reference.groupdocs.com/metadata/python-net/) for the full predicate surface
+
+## See Also
+
+- [In-depth blog article about this project](https://blog.groupdocs.com/metadata/remove-pii-from-office-files-python-net/) – business context and the full pipeline
+- [Clean metadata](https://docs.groupdocs.com/metadata/python-net/clean-metadata/) – reference for the sanitize() behavior
+- [Remove metadata properties](https://docs.groupdocs.com/metadata/python-net/remove-metadata-properties/) – predicate-driven removal across formats
+- [Product documentation](https://docs.groupdocs.com/metadata/python-net/) – getting started and advanced topics
+- [API Reference](https://reference.groupdocs.com/metadata/python-net/) – full API details for GroupDocs.Metadata for Python via .NET


### PR DESCRIPTION
New draft use-case page comparing five PII removal methods for Office documents with GroupDocs.Metadata for Python via .NET, including the verification scan. Section index updated; frontmatter stays draft: true.